### PR TITLE
fix: prevent hist dir clashing

### DIFF
--- a/include/ThreadedDoocsServer.h
+++ b/include/ThreadedDoocsServer.h
@@ -54,6 +54,10 @@ class ThreadedDoocsServer {
     // also need to have symlink for the executable with the new name
     boost::filesystem::create_symlink(_serverName, _serverNameInstance);
 
+    // set directory name for history files
+    std::string histdir = "hist_" + _serverName;
+    setenv("HIST_DIR", histdir.c_str(), true);
+
     // update config file with the RPC number and BPN
     std::string command = "sed " + _configFile + " -e 's/^SVR.RPC_NUMBER:.*$/SVR.RPC_NUMBER: " + rpcNo() +
         "/' -e 's/^SVR.BPN:.*$/SVR.BPN: " + bpn() + "/' > " + _configFileInstance;

--- a/include/ThreadedDoocsServer.h
+++ b/include/ThreadedDoocsServer.h
@@ -1,17 +1,16 @@
 #pragma once
 
+#include "doocsServerTestHelper.h"
+#include <doocs/Server.h>
+#include <eq_fct.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/interprocess/sync/file_lock.hpp>
+
+#include <memory>
 #include <random>
 #include <string>
 #include <thread>
-#include <memory>
-#include <doocs/Server.h>
-
-#include "doocsServerTestHelper.h"
-
-#include <boost/interprocess/sync/file_lock.hpp>
-#include <boost/filesystem.hpp>
-
-#include <eq_fct.h>
 
 #ifndef object_name
 extern const char* object_name;

--- a/include/doocsServerTestHelper.h
+++ b/include/doocsServerTestHelper.h
@@ -10,16 +10,16 @@
 #ifndef DOOCS_SERVER_TEST_HELPER_H
 #define DOOCS_SERVER_TEST_HELPER_H
 
-#include <cassert>
+#include <doocs/Server.h>
+#include <eq_fct.h>
+#include <type_traits>
 
 #include <atomic>
+#include <cassert>
 #include <future>
+#include <iostream>
 #include <mutex>
 #include <signal.h>
-#include <type_traits>
-#include <iostream>
-#include <eq_fct.h>
-#include <doocs/Server.h>
 
 class HelperTest;
 
@@ -176,9 +176,7 @@ void DoocsServerTestHelper::doocsSet(const std::string& name, const std::vector<
   else if(typeid(TYPE) == typeid(short)) {
     ed.set_type(DATA_A_SHORT);
   }
-  else if(typeid(TYPE) == typeid(long long int)
-        || typeid(TYPE) == typeid(int32_t)
-        || typeid(TYPE) == typeid(int64_t)){
+  else if(typeid(TYPE) == typeid(long long int) || typeid(TYPE) == typeid(int32_t) || typeid(TYPE) == typeid(int64_t)) {
     ed.set_type(DATA_A_LONG);
   }
   else if(typeid(TYPE) == typeid(float)) {

--- a/src/doocsServerTestHelper.cc
+++ b/src/doocsServerTestHelper.cc
@@ -5,15 +5,15 @@
  *      Author: Martin Hierholzer
  */
 
-#include <signal.h>
+#include "doocsServerTestHelper.h"
+
+#include <doocs/EqFctSvr.h>
+#include <eq_fct.h>
 #include <sys/types.h>
+
+#include <signal.h>
 #include <time.h>
 #include <unistd.h>
-
-#include <eq_fct.h>
-#include <doocs/EqFctSvr.h>
-
-#include "doocsServerTestHelper.h"
 
 /**********************************************************************************************************************/
 
@@ -77,8 +77,8 @@ void DoocsServerTestHelper::initialise(doocs::Server* server) {
 /**********************************************************************************************************************/
 
 void DoocsServerTestHelper::initialise(HelperTest*) {
-  // I just put the HelperTest into the signaure to indicate that this function is not part of the regular API and only used in tests
-  // of the DoocsServerTestHelper itself.
+  // I just put the HelperTest into the signaure to indicate that this function is not part of the regular API and only
+  // used in tests of the DoocsServerTestHelper itself.
   is_initialised = true;
 }
 

--- a/tests/executables_src/testDoocsServerTestHelper_skeleton.h
+++ b/tests/executables_src/testDoocsServerTestHelper_skeleton.h
@@ -5,15 +5,15 @@
  * executables but share most of its code.
  */
 
+#include "doocsServerTestHelper.h"
+
 #include <boost/test/included/unit_test.hpp>
+
 #include <future>
 #include <mutex>
 #include <queue>
-
 #include <signal.h>
 #include <time.h>
-
-#include "doocsServerTestHelper.h"
 
 using namespace boost::unit_test_framework;
 
@@ -64,7 +64,7 @@ class HelperTestSuite : public test_suite {
     add(BOOST_CLASS_TEST_CASE(&HelperTest::testRoutine, HelperTestPtr));
   }
 };
-test_suite* init_unit_test_suite(int /*argc*/, char* /*argv*/ []) {
+test_suite* init_unit_test_suite(int /*argc*/, char* /*argv*/[]) {
   framework::master_test_suite().p_name.value = "DoocsServerTestHelper class test suite";
   framework::master_test_suite().add(new HelperTestSuite());
 


### PR DESCRIPTION
If tests (e.g. from DoocsAdapter) are run in parallel, the history files
need to be placed into separate directories to prevent tests
disturbing each other. This can even lead to weird crashes (memory
access violations and stack smashing).